### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/app/components/global/footer.tsx
+++ b/app/components/global/footer.tsx
@@ -27,7 +27,7 @@ const navLinks = [
 const socialItems = [
     {
         name: "Twitter",
-        href: "https://twitter.com/glorylaboratory",
+        href: "https://x.com/glorylaboratory",
         icon: (props: SocialIconProps) => <Icon {...props} icon="fontisto:twitter" />,
     },
     {

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -46,7 +46,7 @@ export default function ContactPage() {
                 >
                     <Link
                         className="w-full h-full flex flex-col items-center justify-center"
-                        to="https://twitter.com/glorylaboratory" target="_blank" rel="noreferrer">
+                        to="https://x.com/glorylaboratory" target="_blank" rel="noreferrer">
                         <div className="flex flex-row justify-center items-center gap-4 group-hover:translate-x-1 lg:group-hover:translate-y-1 transition-all">
                             <Icon
                                 icon="simple-icons:x"


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com to reflect the platform's rebranding.